### PR TITLE
RNMT-3293 InAppBrowser Plugin ::: Soft Keyboard breaks UI part 2

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -909,6 +909,13 @@ BOOL isExiting = FALSE;
     self.topBarView.backgroundColor = [UIColor whiteColor];
     [self.view addSubview:self.topBarView];
     [self.view sendSubviewToBack:self.topBarView];
+    
+    if (@available(iOS 12.0, *)) {
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(keyboardWillHide)
+                   name:UIKeyboardWillHideNotification object:nil];
+    }
 }
 
 - (void) setWebViewFrame : (CGRect) frame {
@@ -1168,6 +1175,17 @@ BOOL isExiting = FALSE;
         [self.webView setFrame:CGRectMake(self.webView.frame.origin.x, TOOLBAR_HEIGHT, self.webView.frame.size.width, self.webView.frame.size.height)];
         [self.topBarView setFrame:CGRectMake(self.topBarView.frame.origin.x, self.topBarView.frame.origin.y, self.topBarView.frame.size.width, self.webView.frame.origin.y)];
         [self.toolbar setFrame:CGRectMake(self.toolbar.frame.origin.x, [self getStatusBarOffset], self.toolbar.frame.size.width, self.toolbar.frame.size.height)];
+    }
+}
+
+- (void)keyboardWillHide {
+    if (self.webView) {
+        for (UIView* view in self.webView.subviews) {
+            if ([view isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *scrollView = (UIScrollView*)view;
+                [scrollView setContentOffset:CGPointMake(0, 0)];
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR changes the CDVWKInAppBrowser.m file so that UI no longer breaks due to the soft keyboard when displaying content with viewport-fit=cover in WKWebView.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-3293

<!--- Why is this change required? What problem does it solve? -->
Known WKWebView issue. Only happens in iOS 12 and later.

Issue link in cordova-ios: https://github.com/apache/cordova-ios/issues/417
Original fix patch: https://github.com/kozmanbalint/cordova-plugin-wkwebview-engine/commit/644fc16cff715bc4f7ad6fc2073d9e3eba682c51

Excerpt from the issue link: When an input that would require webview centering is clicked, the viewport is repositioned to center that input, as iOS has traditionally done. However, when dismissing the keyboard, the viewport is not re-positioned properly back to its original position.

Same issue as https://outsystemsrd.atlassian.net/browse/RNMT-3213

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Applied this fix manually to an app built with MABS 6 that uses the InAppBrowser Plugin. The issue stopped happening.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly