### PR TITLE
RNMT-3299 InAppBrowser Plugin ::: OutSystems app does not open if it is the first open call

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1097,6 +1097,12 @@ BOOL isExiting = FALSE;
         [CDVUserAgentUtil acquireLock:^(NSInteger lockToken) {
             _userAgentLockToken = lockToken;
             [CDVUserAgentUtil setUserAgent:_userAgent lockToken:lockToken];
+            /*
+             * RNMT-3299
+             * For some reason the above line does not override our User-Agent in the first open of a WKWebView.
+             * To fix this we added the following line.
+             */
+            weakSelf.webView.customUserAgent = _userAgent;
             [weakSelf.webView loadRequest:request];
         }];
     }
@@ -1236,6 +1242,10 @@ BOOL isExiting = FALSE;
     //    from it must pass through its white-list. This *does* break PDFs that
     //    contain links to other remote PDF/websites.
     // More info at https://issues.apache.org/jira/browse/CB-2225
+    /*
+     * RNMT-3299
+     * Add this here to cause a conflict if anything related to this is changed.
+     */
     BOOL isPDF = NO;
     //TODO webview class
     //BOOL isPDF = [@"true" isEqualToString :[theWebView evaluateJavaScript:@"document.body==null"]];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed incorrect User-Agent in the first usage of open.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-3299

<!--- Why is this change required? What problem does it solve? -->
The setUserAgent method is supposed to manage the User-Agent used by every UIWebView and WKWebView in an application. For some reason this is not working with our User-Agent in the first call of open (only when using a WKWebView).

It works with UIWebView and it works with a different value of User-Agent, which points to a potential bug in the WKWebView engine plugin (possibly not detecting a change to the value because one is a prefix of the other).

To fix this we are using the customUserAgent property of the WKWebView. Setting this makes every request use the intended value.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
According to comments in the code, the usage of the setUserAgent method has the goal of managing an edge case related with loading PDFs. Apparently loading a PDF updates the value of the User-Agent in every UIWebView and WKWebView.

Tested an app that opens the InAppBrowser with different URLs, including PDFs, pages that embed PDFs and pages that can lead to opening PDFs (and following the links until the PDF is open). After every step the navigator.userAgent property was checked both in the main WKWebView and in the InAppBrowser using the Safari inspector.

The User-Agent value was always the expected one.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly