### PR TITLE
RNMT-3631 InAppBrowser ::: Issue with dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixes
+- Background color now takes dark mode into account [RNMT-3631](https://outsystemsrd.atlassian.net/browse/RNMT-3631)
+- Improvements to view positioning depending on which options are used [RNMT-3631](https://outsystemsrd.atlassian.net/browse/RNMT-3631)
+- Fixes related to the usage of safe area insets [RNMT-3631](https://outsystemsrd.atlassian.net/browse/RNMT-3631)
+
+## [3.1.0-OS2] - 2019-10-04
+### Fixes
+- Now opens in iOS 13 when using WKWebView [RNMT-3324](https://outsystemsrd.atlassian.net/browse/RNMT-3324)
+- Options unmarshalling is now based on property type instead of content type [RNMT-3309](https://outsystemsrd.atlassian.net/browse/RNMT-3309)
+
+## [3.1.0-OS1] - 2019-09-17
+### Fixes
+- User-Agent is no longer incorrect in the first usage of open [RNMT-3299](https://outsystemsrd.atlassian.net/browse/RNMT-3299)
+- Keyboard no longer breaks UI due to scroll view not being repositioned [RNMT-3293](https://outsystemsrd.atlassian.net/browse/RNMT-3293)
+
+## [3.1.0-OS] - 2019-09-10
+### Changes
+- Merge upstream (3.1.0) into OutSystems branch [RNMT-3220](https://outsystemsrd.atlassian.net/browse/RNMT-3220)
+
+### Additions
+- Use WKWebView engine when available [RNMT-3220](https://outsystemsrd.atlassian.net/browse/RNMT-3220)
+
+### Fixes
+- Top safe area inset is now being correctly used when using WKWebView [RNMT-3220](https://outsystemsrd.atlassian.net/browse/RNMT-3220)
+
+## [3.0.0-OS1] - 2019-06-04
+### Additions
+- Add a hook to conditionally set cleartextTrafficPermitted to true [RNMT-2921](https://outsystemsrd.atlassian.net/browse/RNMT-2921)
+
+## [3.0.0-os] - 2018-12-04
+### Changes
+- Merge upstream (3.0.0) into OutSystems branch
+
+[Unreleased]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/3.1.0-OS2...HEAD
+[3.1.0-OS2]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/3.1.0-OS1...3.1.0-OS2
+[3.1.0-OS1]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/3.1.0-OS...3.1.0-OS1
+[3.1.0-OS]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/3.0.0-OS1...3.1.0-OS
+[3.0.0-OS1]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/3.0.0-os...3.0.0-OS1
+[3.0.0-os]: https://github.com/OutSystems/cordova-plugin-inappbrowser/compare/1.7.0-os...3.0.0-os

--- a/src/ios/CDVUIInAppBrowser.h
+++ b/src/ios/CDVUIInAppBrowser.h
@@ -75,6 +75,7 @@
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;
 @property (nonatomic, strong) IBOutlet UIToolbar* toolbar;
+@property (nonatomic, strong) IBOutlet UIView* backgroundView;
 
 @property (nonatomic, weak) id <CDVScreenOrientationDelegate> orientationDelegate;
 @property (nonatomic, weak) CDVUIInAppBrowser* navigationDelegate;

--- a/src/ios/CDVUIInAppBrowser.m
+++ b/src/ios/CDVUIInAppBrowser.m
@@ -781,7 +781,12 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     self.view.backgroundColor = IsAtLeastiOSVersion(@"13.0") ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
+#else
+    self.view.backgroundColor = [UIColor whiteColor];
+#endif
+
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];

--- a/src/ios/CDVUIInAppBrowser.m
+++ b/src/ios/CDVUIInAppBrowser.m
@@ -788,6 +788,7 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
 
     UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
     self.backgroundView = [[UIView alloc] initWithFrame:CGRectMake(0, insets.top, self.view.bounds.size.width, self.view.bounds.size.height - insets.top - insets.bottom)];
+    self.backgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.backgroundView.backgroundColor = [UIColor grayColor];
     [self.view addSubview:self.backgroundView];
     [self.view sendSubviewToBack:self.backgroundView];

--- a/src/ios/CDVUIInAppBrowser.m
+++ b/src/ios/CDVUIInAppBrowser.m
@@ -781,12 +781,12 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
 
-    self.view.backgroundColor = [[[UIDevice currentDevice] systemVersion] floatValue] >= 13 ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
+    self.view.backgroundColor = IsAtLeastiOSVersion(@"13.0") ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];
 
-    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+    UIEdgeInsets insets = [self getWindowSafeAreaInsets];
     self.backgroundView = [[UIView alloc] initWithFrame:CGRectMake(0, insets.top, self.view.bounds.size.width, self.view.bounds.size.height - insets.top - insets.bottom)];
     self.backgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.backgroundView.backgroundColor = [UIColor grayColor];
@@ -1016,7 +1016,7 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
 }
 
 - (void) positionViews:(NSArray *)views {
-    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+    UIEdgeInsets insets = [self getWindowSafeAreaInsets];
     
     CGFloat webViewHeight = self.view.bounds.size.height - insets.top - insets.bottom;
     for (UIView *view in views) {
@@ -1033,6 +1033,16 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
             y += height;
         }
     }
+}
+
+//
+// iOS 11 introduced safe area insets. Before this the whole screen was used except for the status bar at the
+// top of the screen.
+//
+- (UIEdgeInsets) getWindowSafeAreaInsets {
+    return IsAtLeastiOSVersion(@"11.0") ?
+            [[[UIApplication sharedApplication] delegate] window].safeAreaInsets :
+            UIEdgeInsetsMake([self getStatusBarOffset], 0, 0, 0);
 }
 
 //

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -65,7 +65,7 @@
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;
 @property (nonatomic, strong) IBOutlet UIToolbar* toolbar;
-@property (nonatomic, strong) IBOutlet UIView* topBarView;
+@property (nonatomic, strong) IBOutlet UIView* backgroundView;
 @property (nonatomic, strong) IBOutlet CDVWKInAppBrowserUIDelegate* webViewUIDelegate;
 
 @property (nonatomic, weak) id <CDVScreenOrientationDelegate> orientationDelegate;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -920,6 +920,7 @@ BOOL isExiting = FALSE;
     
     UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
     self.backgroundView = [[UIView alloc] initWithFrame:CGRectMake(0, insets.top, self.view.bounds.size.width, self.view.bounds.size.height - insets.top - insets.bottom)];
+    self.backgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.backgroundView.backgroundColor = [UIColor grayColor];
     [self.view addSubview:self.backgroundView];
     [self.view sendSubviewToBack:self.backgroundView];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -839,7 +839,7 @@ BOOL isExiting = FALSE;
     self.toolbar.autoresizingMask = toolbarIsAtBottom ? (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin) : UIViewAutoresizingFlexibleWidth;
     self.toolbar.barStyle = UIBarStyleBlackOpaque;
     self.toolbar.clearsContextBeforeDrawing = NO;
-    self.toolbar.clipsToBounds = NO;
+    self.toolbar.clipsToBounds = YES;
     self.toolbar.contentMode = UIViewContentModeScaleToFill;
     self.toolbar.hidden = NO;
     self.toolbar.multipleTouchEnabled = NO;
@@ -913,15 +913,16 @@ BOOL isExiting = FALSE;
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
     
-    self.view.backgroundColor = [UIColor grayColor];
+    self.view.backgroundColor = [[[UIDevice currentDevice] systemVersion] floatValue] >= 13 ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];
     
-    self.topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, webViewBounds.size.width, webViewBounds.origin.y)];
-    self.topBarView.backgroundColor = [[[UIDevice currentDevice] systemVersion] floatValue] >= 13 ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
-    [self.view addSubview:self.topBarView];
-    [self.view sendSubviewToBack:self.topBarView];
+    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+    self.backgroundView = [[UIView alloc] initWithFrame:CGRectMake(0, insets.top, self.view.bounds.size.width, self.view.bounds.size.height - insets.top - insets.bottom)];
+    self.backgroundView.backgroundColor = [UIColor grayColor];
+    [self.view addSubview:self.backgroundView];
+    [self.view sendSubviewToBack:self.backgroundView];
     
     if (@available(iOS 12.0, *)) {
         [[NSNotificationCenter defaultCenter]
@@ -1138,44 +1139,39 @@ BOOL isExiting = FALSE;
     [self.webView goForward];
 }
 
-- (BOOL)hasTopNotch {
-    if (@available(iOS 11.0, *)) {
-        return [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.top > 20.0;
-    }
-    
-    return  NO;
-}
-
 - (void)viewWillAppear:(BOOL)animated
 {
     if (IsAtLeastiOSVersion(@"7.0") && !viewRenderedAtLeastOnce) {
         viewRenderedAtLeastOnce = TRUE;
-        CGRect viewBounds = [self.webView bounds];
         
-        if ([self hasTopNotch]) {
-            BOOL toolbarVisible = !self.toolbar.hidden;
-            BOOL toolbarIsAtBottom = ![_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop];
-            
-            float topSafeArea = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.top;
-            float bottomSafeArea = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.bottom;
-            
-            if (toolbarVisible && toolbarIsAtBottom) {
-                bottomSafeArea = 0.0;
-            }
-            
-            viewBounds.origin.y = topSafeArea;
-            viewBounds.size.height = viewBounds.size.height - (topSafeArea + bottomSafeArea);
+        if ([_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop]) {
+            [self positionViews:@[ self.toolbar, self.webView, self.addressLabel ]];
         } else {
-            viewBounds.origin.y = STATUSBAR_HEIGHT;
-            viewBounds.size.height = viewBounds.size.height - STATUSBAR_HEIGHT;
+            [self positionViews:@[ self.webView, self.toolbar, self.addressLabel ]];
         }
-        self.webView.frame = viewBounds;
-        self.topBarView.frame = CGRectMake(0, 0, viewBounds.size.width, viewBounds.origin.y);
-        [[UIApplication sharedApplication] setStatusBarStyle:[self preferredStatusBarStyle]];
     }
-    [self rePositionViews];
     
     [super viewWillAppear:animated];
+}
+
+- (void) positionViews:(NSArray *)views {
+    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+    
+    CGFloat webViewHeight = self.view.bounds.size.height - insets.top - insets.bottom;
+    for (UIView *view in views) {
+        if (!view.hidden && view != self.webView) {
+            webViewHeight -= view.bounds.size.height;
+        }
+    }
+    
+    CGFloat y = insets.top;
+    for (UIView *view in views) {
+        if (!view.hidden) {
+            CGFloat height = view != self.webView ? view.bounds.size.height : webViewHeight;
+            view.frame = CGRectMake(0, y, self.view.bounds.size.width, height);
+            y += height;
+        }
+    }
 }
 
 //
@@ -1187,14 +1183,6 @@ BOOL isExiting = FALSE;
     CGRect statusBarFrame = [[UIApplication sharedApplication] statusBarFrame];
     float statusBarOffset = IsAtLeastiOSVersion(@"7.0") ? MIN(statusBarFrame.size.width, statusBarFrame.size.height) : 0.0;
     return statusBarOffset;
-}
-
-- (void) rePositionViews {
-    if ([_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop]) {
-        [self.webView setFrame:CGRectMake(self.webView.frame.origin.x, TOOLBAR_HEIGHT, self.webView.frame.size.width, self.webView.frame.size.height)];
-        [self.topBarView setFrame:CGRectMake(self.topBarView.frame.origin.x, self.topBarView.frame.origin.y, self.topBarView.frame.size.width, self.webView.frame.origin.y)];
-        [self.toolbar setFrame:CGRectMake(self.toolbar.frame.origin.x, [self getStatusBarOffset], self.toolbar.frame.size.width, self.toolbar.frame.size.height)];
-    }
 }
 
 - (void)keyboardWillHide {

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -912,8 +912,13 @@ BOOL isExiting = FALSE;
     } else {
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
-    
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     self.view.backgroundColor = IsAtLeastiOSVersion(@"13.0") ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
+#else
+    self.view.backgroundColor = [UIColor whiteColor];
+#endif
+
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -913,18 +913,18 @@ BOOL isExiting = FALSE;
         [self.toolbar setItems:@[self.closeButton, flexibleSpaceButton, self.backButton, fixedSpaceButton, self.forwardButton]];
     }
     
-    self.view.backgroundColor = [[[UIDevice currentDevice] systemVersion] floatValue] >= 13 ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
+    self.view.backgroundColor = IsAtLeastiOSVersion(@"13.0") ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
     [self.view addSubview:self.toolbar];
     [self.view addSubview:self.addressLabel];
     [self.view addSubview:self.spinner];
-    
-    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+
+    UIEdgeInsets insets = [self getWindowSafeAreaInsets];
     self.backgroundView = [[UIView alloc] initWithFrame:CGRectMake(0, insets.top, self.view.bounds.size.width, self.view.bounds.size.height - insets.top - insets.bottom)];
     self.backgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.backgroundView.backgroundColor = [UIColor grayColor];
     [self.view addSubview:self.backgroundView];
     [self.view sendSubviewToBack:self.backgroundView];
-    
+
     if (@available(iOS 12.0, *)) {
         [[NSNotificationCenter defaultCenter]
             addObserver:self
@@ -1156,7 +1156,7 @@ BOOL isExiting = FALSE;
 }
 
 - (void) positionViews:(NSArray *)views {
-    UIEdgeInsets insets = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets;
+    UIEdgeInsets insets = [self getWindowSafeAreaInsets];
     
     CGFloat webViewHeight = self.view.bounds.size.height - insets.top - insets.bottom;
     for (UIView *view in views) {
@@ -1173,6 +1173,16 @@ BOOL isExiting = FALSE;
             y += height;
         }
     }
+}
+
+//
+// iOS 11 introduced safe area insets. Before this the whole screen was used except for the status bar at the
+// top of the screen.
+//
+- (UIEdgeInsets) getWindowSafeAreaInsets {
+    return IsAtLeastiOSVersion(@"11.0") ?
+            [[[UIApplication sharedApplication] delegate] window].safeAreaInsets :
+            UIEdgeInsetsMake([self getStatusBarOffset], 0, 0, 0);
 }
 
 //

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -919,7 +919,7 @@ BOOL isExiting = FALSE;
     [self.view addSubview:self.spinner];
     
     self.topBarView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, webViewBounds.size.width, webViewBounds.origin.y)];
-    self.topBarView.backgroundColor = [UIColor whiteColor];
+    self.topBarView.backgroundColor = [[[UIDevice currentDevice] systemVersion] floatValue] >= 13 ? [UIColor systemBackgroundColor] : [UIColor whiteColor];
     [self.view addSubview:self.topBarView];
     [self.view sendSubviewToBack:self.topBarView];
     


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed status bar background color in dark mode when using WKWebView.

This color was always white. Now it uses the system background color when using iOS 13+.

There is a very slight color discrepancy when not using the dark mode in a device with notch (this exists since the latest pull from upstream). This behaviour is also present in devices using iOS 12- (which do not use dark mode). No issues when using devices without notch.

Also fixed multiple UI issues related with options that change the visibility/positioning of views. Now also takes into account safe area insets.

Fixed when using either WKWebView or UIWebView.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3631

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manually tested the fix.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

<img width="535" alt="Screenshot 2020-01-02 at 17 34 41" src="https://user-images.githubusercontent.com/45076576/71682559-f9065c80-2d87-11ea-9b07-4e3391b8f83e.png">
<img width="535" alt="Screenshot 2020-01-02 at 17 35 02" src="https://user-images.githubusercontent.com/45076576/71682566-fc014d00-2d87-11ea-96aa-b6d13d707097.png">
<img width="535" alt="Screenshot 2020-01-02 at 17 35 33" src="https://user-images.githubusercontent.com/45076576/71682568-fdcb1080-2d87-11ea-8bb4-1ee7e8118b79.png">
<img width="547" alt="Screenshot 2020-01-02 at 17 36 03" src="https://user-images.githubusercontent.com/45076576/71682570-002d6a80-2d88-11ea-8cc1-547a1f4564a3.png">
<img width="547" alt="Screenshot 2020-01-02 at 17 36 21" src="https://user-images.githubusercontent.com/45076576/71682576-028fc480-2d88-11ea-9ea0-64b0007ab7e4.png">

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly