### PR TITLE
RNMT-3569 Removes support for UIWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changes
+- Add compile-time decision for disabling UIWebView [RNMT-3569](https://outsystemsrd.atlassian.net/browse/RNMT-3569)
+
 ### Fixes
 - Background color now takes dark mode into account [RNMT-3631](https://outsystemsrd.atlassian.net/browse/RNMT-3631)
 - Improvements to view positioning depending on which options are used [RNMT-3631](https://outsystemsrd.atlassian.net/browse/RNMT-3631)

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -19,7 +19,9 @@
 
 #import "CDVInAppBrowser.h"
 #import "CDVInAppBrowserOptions.h"
+#if !WK_WEB_VIEW_ONLY
 #import "CDVUIInAppBrowser.h"
+#endif
 #import "CDVWKInAppBrowser.h"
 #import <Cordova/CDVPluginResult.h>
 
@@ -41,85 +43,121 @@
 
 - (void)open:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] open:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] open:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] open:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] open:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] open:command];
+      }
+    #endif
 }
 
 - (void)close:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] close:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] close:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] close:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] close:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] close:command];
+      }
+    #endif
 }
 
 
 - (void)show:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] show:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] show:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] show:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] show:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] show:command];
+      }
+    #endif
 }
 
 - (void)hide:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] hide:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] hide:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] hide:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] hide:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] hide:command];
+      }
+    #endif
 }
 
 
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] injectScriptCode:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] injectScriptCode:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] injectScriptCode:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] injectScriptCode:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] injectScriptCode:command];
+      }
+    #endif
 }
 
 - (void)injectScriptFile:(CDVInvokedUrlCommand*)command
 {
-     if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] injectScriptFile:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] injectScriptFile:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] injectScriptCode:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] injectScriptCode:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] injectScriptCode:command];
+      }
+    #endif
 }
 
 - (void)injectStyleCode:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] injectStyleCode:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] injectStyleCode:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] injectStyleCode:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] injectStyleCode:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] injectStyleCode:command];
+      }
+    #endif
 }
 
 - (void)injectStyleFile:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] injectStyleFile:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] injectStyleFile:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] injectStyleFile:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] injectStyleFile:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] injectStyleFile:command];
+      }
+    #endif
 }
 
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command
 {
-    if(self.usewkwebview){
-        [[CDVWKInAppBrowser getInstance] loadAfterBeforeload:command];
-    }else{
-        [[CDVUIInAppBrowser getInstance] loadAfterBeforeload:command];
-    }
+    #if WK_WEB_VIEW_ONLY
+      [[CDVWKInAppBrowser getInstance] loadAfterBeforeload:command];
+    #else
+      if(self.usewkwebview){
+          [[CDVWKInAppBrowser getInstance] loadAfterBeforeload:command];
+      }else{
+          [[CDVUIInAppBrowser getInstance] loadAfterBeforeload:command];
+      }
+    #endif
 }
 
 

--- a/src/ios/CDVUIInAppBrowser.h
+++ b/src/ios/CDVUIInAppBrowser.h
@@ -17,6 +17,8 @@
  under the License.
  */
 
+#if !WK_WEB_VIEW_ONLY
+
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVInvokedUrlCommand.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
@@ -90,3 +92,5 @@
 - (id)initWithUserAgent:(NSString*)userAgent prevUserAgent:(NSString*)prevUserAgent browserOptions: (CDVInAppBrowserOptions*) browserOptions;
 
 @end
+
+#endif

--- a/src/ios/CDVUIInAppBrowser.m
+++ b/src/ios/CDVUIInAppBrowser.m
@@ -17,6 +17,8 @@
  under the License.
  */
 
+#if !WK_WEB_VIEW_ONLY
+
 #import "CDVUIInAppBrowser.h"
 #import <Cordova/CDVPluginResult.h>
 #import <Cordova/CDVUserAgentUtil.h>
@@ -1173,4 +1175,4 @@ BOOL viewRenderedAtLeastOneTime = FALSE;
 
 @end
 
-
+#endif


### PR DESCRIPTION
Adds compile-time decision for disabling UIWebView.

These changes are retro compatible and the plugin will compile and work just fine if the preference is missing as is the case with older MABS versions.