### PR TITLE
Add CI pipelines to InAppBrowserPlugin

### DIFF
--- a/CI/azure-pipeline-develop.yml
+++ b/CI/azure-pipeline-develop.yml
@@ -1,0 +1,12 @@
+name: 'Develop'
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+    - outsystems
+
+stages:
+- template: 'templates/tests-stage.yml'
+  parameters:
+    platforms: ['ios', 'js'] # Platforms to test for, it can be 'all' to test all

--- a/CI/azure-pipeline-release.yml
+++ b/CI/azure-pipeline-release.yml
@@ -1,0 +1,22 @@
+# Squeleton of a could be a staging pipeline, stages need to be checked for the needs
+# When a tag is set in the outsystems branch, a release pipeline will start that will:
+# - run unit tests
+# - deploy to test env and start UI Tests
+# - deploy to outsystems release env
+
+# Known problems UItests is a different pipeline.
+
+name: 'Release'
+trigger:
+  tags:
+    include:
+    - '*'
+
+stages:
+  - template: 'templates/tests-stage.yml'
+    parameters:
+      platforms: ['all'] # Platforms to test for, it can be 'all' to test all ('ios', 'js', 'android')
+  - template: 'templates/deploy-test-env-stage.yml' # Deployment Job to deploy code for UI Testing
+    parameters:
+      shouldRunTests: true # Run the UI Tests immediately after deployment
+      release: ['github', 'outsystems'] # Platforms to release for, it can be empty if there should be no release

--- a/CI/azure-pipeline-staging.yml
+++ b/CI/azure-pipeline-staging.yml
@@ -1,0 +1,12 @@
+# Squeleton of a could be a staging pipeline, stages need to be checked for the needs
+
+name: 'Staging'
+trigger:
+  - master
+  - outsystems
+
+stages:
+  - template: 'templates/tests-stage.yml'
+    parameters:
+      platforms: ['all'] # Platforms to test for, it can be 'all' to test all ('ios', 'js', 'android')
+  - template: 'templates/deploy-test-env-stage.yml' # Deployment Job to deploy code for UI Testing

--- a/CI/templates/android-tests-job.yml
+++ b/CI/templates/android-tests-job.yml
@@ -1,0 +1,18 @@
+# For now just a simple squeleton needs proper setting for android build and tests tasks
+
+parameters:
+- name: workingDirectory
+  type: string
+  default: ''
+
+jobs:
+  - job: AndroidTest
+    displayName: 'Android Tests'
+    pool:
+      vmImage: 'macOS'
+    steps:
+    - template: 'npm-steps.yml'
+      parameters:
+        workingDirectory: ${{ parameters.workingDirectory }}
+    - script: 'echo successful tests' # Mocked response
+      workingDirectory: ${{ parameters.workingDirectory }}

--- a/CI/templates/deploy-test-env-stage.yml
+++ b/CI/templates/deploy-test-env-stage.yml
@@ -1,0 +1,21 @@
+# For now just a simple squeleton needs proper setting for deployment to ui test env
+parameters:
+  shouldRunTests: false
+  release: []
+
+
+stages:
+  - stage: Deployment
+    jobs:
+      - job: deploy_test_env
+        displayName: 'Deployment Test Env'
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - script: 'echo Mocked Response successful deployment' # Mocked response
+        - ${{ if eq(parameters.shouldRunTests, true) }}:
+          - script: 'echo WIP Mocked Response UITests all passed' # Mocked response
+        - ${{ if containsValue(parameters.release, 'github') }}:
+          - script: 'echo WIP Mocked Response successful release to github' # Mocked response
+        - ${{ if containsValue(parameters.release, 'outsystems') }}:
+          - script: 'echo WIP Mocked Response successful release to outsystems' # Mocked response

--- a/CI/templates/ios-tests-job.yml
+++ b/CI/templates/ios-tests-job.yml
@@ -1,0 +1,53 @@
+parameters:
+- name: scheme
+  type: string
+  default:
+- name: configuration
+  type: string
+  default: Debug
+- name: xcodeVersion
+  type: string
+  default: default
+- name: workingDirectory
+  type: string
+  default: ''
+- name: destinationPlatform
+  type: string
+  default: iOS Simulator
+- name: destinationName
+  type: string
+  default: iPhone 8
+- name: shouldClean
+  type: boolean
+  default: true
+- name: sdk
+  type: string
+  default: 'iphonesimulator'
+
+jobs:
+  - job: iOSTest
+    displayName: 'iOS Tests'
+    pool:
+      vmImage: 'macOS'
+    steps:
+    - template: 'npm-steps.yml'
+      parameters:
+        workingDirectory: ${{ parameters.workingDirectory }}
+    - task: Xcode@5
+      inputs:
+        ${{ if eq(parameters.shouldClean, true) }}:
+          actions: 'clean build test'
+        ${{ if not(eq(parameters.shouldClean, true)) }}:
+          actions: 'build test'
+        scheme: '${{ parameters.scheme }}'
+        sdk: '${{ parameters.sdk }}'
+        xcodeVersion: '${{ parameters.xcodeVersion }}'
+        configuration: '${{ parameters.configuration }}'
+        xcWorkspacePath: '${{ parameters.workingDirectory }}/**/*.xcodeproj/project.xcworkspace'
+        exportPath: '$(agent.buildDirectory)/output/$(sdk)/$(configuration)'
+        packageApp: false
+        destinationSimulators: '${{ parameters.destinationName }}'
+        destinationPlatform: iOS
+        args: -destination "platform=${{ parameters.destinationPlatform }},name=${{ parameters.destinationName }}"
+        useXcpretty: true
+        publishJUnitResults: true

--- a/CI/templates/js-tests-job.yml
+++ b/CI/templates/js-tests-job.yml
@@ -1,0 +1,18 @@
+# For now just a simple squeleton needs proper setting for js build and tests tasks
+
+parameters:
+- name: workingDirectory
+  type: string
+  default: ''
+
+jobs:
+  - job: jsTest
+    displayName: 'JS Tests'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - template: 'npm-steps.yml'
+      parameters:
+        workingDirectory: ${{ parameters.workingDirectory }}
+    - script: 'echo successful tests' # Mocked response
+      workingDirectory: ${{ parameters.workingDirectory }}

--- a/CI/templates/npm-steps.yml
+++ b/CI/templates/npm-steps.yml
@@ -1,0 +1,13 @@
+parameters:
+- name: workingDirectory # name of the parameter; required
+  type: string # data type of the parameter; required
+  default: ''
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.x'
+  displayName: 'Install Node.js'
+- script: npm install
+  displayName: 'npm install'
+  workingDirectory:  ${{ parameters.workingDirectory }}

--- a/CI/templates/tests-stage.yml
+++ b/CI/templates/tests-stage.yml
@@ -1,0 +1,19 @@
+parameters:
+ platforms: []
+
+stages:
+- stage: Testing
+  jobs:
+  - ${{ if or(containsValue(parameters.platforms, 'all'), containsValue(parameters.platforms, 'ios')) }}:
+    - template: 'ios-tests-job.yml'
+      parameters:
+        scheme: 'InAppBrowserTests'
+        workingDirectory: 'tests/ios'
+  - ${{ if or(containsValue(parameters.platforms, 'all'), containsValue(parameters.platforms, 'android')) }}:
+    - template: 'android-tests-job.yml'
+      parameters:
+        workingDirectory: 'tests'
+  - ${{ if or(containsValue(parameters.platforms, 'all'), containsValue(parameters.platforms, 'js')) }}:
+    - template: 'js-tests-job.yml'
+      parameters:
+        workingDirectory: 'tests'

--- a/tests/ios/InAppBrowserTests.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/InAppBrowserTests.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/InAppBrowserTests/InAppBrowserTests.xcodeproj/project.pbxproj
+++ b/tests/ios/InAppBrowserTests/InAppBrowserTests.xcodeproj/project.pbxproj
@@ -459,6 +459,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = InAppBrowserTests/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -484,6 +485,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = InAppBrowserTests/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/tests/ios/InAppBrowserTests/InAppBrowserTests.xcodeproj/xcshareddata/xcschemes/InAppBrowserTests.xcscheme
+++ b/tests/ios/InAppBrowserTests/InAppBrowserTests.xcodeproj/xcshareddata/xcschemes/InAppBrowserTests.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAF985FE24DD6AC20011E0AB"
+               BuildableName = "InAppBrowserTests.framework"
+               BlueprintName = "InAppBrowserTests"
+               ReferencedContainer = "container:InAppBrowserTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAF9860724DD6AC20011E0AB"
+               BuildableName = "InAppBrowserTestsTests.xctest"
+               BlueprintName = "InAppBrowserTestsTests"
+               ReferencedContainer = "container:InAppBrowserTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAF985FE24DD6AC20011E0AB"
+            BuildableName = "InAppBrowserTests.framework"
+            BlueprintName = "InAppBrowserTests"
+            ReferencedContainer = "container:InAppBrowserTests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/InAppBrowserTests/InAppBrowserTestsTests/CDVInAppBrowserCacheManagerIntegrationTests.swift
+++ b/tests/ios/InAppBrowserTests/InAppBrowserTestsTests/CDVInAppBrowserCacheManagerIntegrationTests.swift
@@ -8,7 +8,7 @@ class CDVInAppBrowserCacheManagerIntegrationTests: XCTestCase {
     private var target: BrowserCacheManager?
     private var store: WKWebsiteDataStore?
     
-    override func setUpWithError() throws {
+    override func setUp() {
         let store = WKWebsiteDataStore.default()
         target = BrowserCacheManager(dataStore: store)
         self.store = store

--- a/tests/ios/InAppBrowserTests/InAppBrowserTestsTests/InAppBrowserCacheTests.swift
+++ b/tests/ios/InAppBrowserTests/InAppBrowserTestsTests/InAppBrowserCacheTests.swift
@@ -6,7 +6,7 @@ class InAppBrowserCacheTests: XCTestCase {
     private var target: SafariBrowserPlugin?
     private var manager: StubCacheManager?
     
-    override func setUpWithError() throws {
+    override func setUp() {
         let manager = StubCacheManager()
         target = SafariBrowserPlugin(cacheManager: manager)
         self.manager = manager


### PR DESCRIPTION
### Description

This PR is just a draft as an example how the CI as a code could work. It's not final and this is basically a way so everyone can recommend improvements.

Pipelines:

Develop - This pipeline is triggered by PR's with base on master or outsystems branchs. The main purpose is running all Unit tests. Since there are only iOS tests, the other results are mocked.

Staging (Mocked) - The main purpose of this pipeline is running tests every time something changes in the master and outsystems branch. If successful then it should deploy to UI Tests environment.

Release (Mocked) - This one needs real discovery still. But as the main intention of this work is a safe automated CI pipeline ecosystem, this pipeline should be triggered by new tags on outsystems branch and then:
- Run unit tests for available platforms
- Deploy to UI Tests dev environment
- Run UI Tests
- Deploy to release environments (GitHub and/or OutSystems)

### Azure Pipelines

If you want to check the pipelines in Azure

https://dev.azure.com/OutSystemsRD/Mobile%20Supported%20Plugins/_build?definitionScope=%5CInAppBrowser

IAB - Develop
IAB - Staging
IAB - Release

### Known Issues

Yes the pipelines are getting triggered always I believe it is because of this PR also has the pipelines.

### Platforms affected

All