### PR TITLE
RMET-311: Fix user agent being reused in WKWebView for OutsystemsApps.

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -729,15 +729,6 @@ BOOL isExiting = FALSE;
     WKUserContentController* userContentController = [[WKUserContentController alloc] init];
     
     WKWebViewConfiguration* configuration = [[WKWebViewConfiguration alloc] init];
-    
-    NSString *userAgent = configuration.applicationNameForUserAgent;
-    if (
-        [self settingForKey:@"OverrideUserAgent"] == nil &&
-        [self settingForKey:@"AppendUserAgent"] != nil
-        ) {
-        userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, [self settingForKey:@"AppendUserAgent"]];
-    }
-    configuration.applicationNameForUserAgent = userAgent;
     configuration.userContentController = userContentController;
 #if __has_include("CDVWKProcessPoolFactory.h")
     configuration.processPool = [[CDVWKProcessPoolFactory sharedFactory] sharedProcessPool];


### PR DESCRIPTION
A fix introduced in the commit: https://github.com/OutSystems/cordova-plugin-inappbrowser/pull/5 was reintroduced in last version.

This fixes the problem.

https://outsystemsrd.atlassian.net/browse/RMET-311

### Platforms affected

- [ ] iOS
- [ ] Android

### Motivation and Context

Fixes a problem that could happen when opening an Outsystems app from the in app browser.

### Description
Now it doesn't napped Outsystems app V2.9 to the user agent.

### Testing
Tested in sample app by opening all the available URLs. Including OutSystems Apps URLs and downloads.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
