### PR TITLE
RMET-493: Fix code bug where rootName would be always undefined.

### DIFF
--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -49,16 +49,16 @@
         },
         _loadAfterBeforeload: function (strUrl) {
             strUrl = urlutil.makeAbsolute(strUrl);
-            exec(null, null, rootName, 'loadAfterBeforeload', [strUrl]);
+            exec(null, null, this.rootName, 'loadAfterBeforeload', [strUrl]);
         },
         close: function (eventname) {
-            exec(null, null, rootName, 'close', []);
+            exec(null, null, this.rootName, 'close', []);
         },
         show: function (eventname) {
-            exec(null, null, rootName, 'show', []);
+            exec(null, null, this.rootName, 'show', []);
         },
         hide: function (eventname) {
-            exec(null, null, rootName, 'hide', []);
+            exec(null, null, this.rootName, 'hide', []);
         },
         addEventListener: function (eventname, f) {
             if (eventname in this.channels) {
@@ -73,9 +73,9 @@
 
         executeScript: function (injectDetails, cb) {
             if (injectDetails.code) {
-                exec(cb, null, rootName, 'injectScriptCode', [injectDetails.code, !!cb]);
+                exec(cb, null, this.rootName, 'injectScriptCode', [injectDetails.code, !!cb]);
             } else if (injectDetails.file) {
-                exec(cb, null, rootName, 'injectScriptFile', [injectDetails.file, !!cb]);
+                exec(cb, null, this.rootName, 'injectScriptFile', [injectDetails.file, !!cb]);
             } else {
                 throw new Error('executeScript requires exactly one of code or file to be specified');
             }
@@ -83,9 +83,9 @@
 
         insertCSS: function (injectDetails, cb) {
             if (injectDetails.code) {
-                exec(cb, null, rootName, 'injectStyleCode', [injectDetails.code, !!cb]);
+                exec(cb, null, this.rootName, 'injectStyleCode', [injectDetails.code, !!cb]);
             } else if (injectDetails.file) {
-                exec(cb, null, rootName, 'injectStyleFile', [injectDetails.file, !!cb]);
+                exec(cb, null, this.rootName, 'injectStyleFile', [injectDetails.file, !!cb]);
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }


### PR DESCRIPTION
https://outsystemsrd.atlassian.net/browse/RMET-493

### Platforms affected

- All

### Motivation and Context

There was a bug in the code that would make the rootName always undefined.

### Description

The bug has emerged because rootName didn't had a `this.` before its variable name. Adding `this.` before rootName inside the functions will make the code work as expected.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
