### PR TITLE
RMET-552: Fix footer on iPhone X

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1076,6 +1076,7 @@ BOOL isExiting = FALSE;
     // Run later to avoid the "took a long time" log message.
     dispatch_async(dispatch_get_main_queue(), ^{
         isExiting = TRUE;
+        lastReducedStatusBarHeight = 0.0;
         if ([weakSelf respondsToSelector:@selector(presentingViewController)]) {
             [[weakSelf presentingViewController] dismissViewControllerAnimated:YES completion:nil];
         } else {


### PR DESCRIPTION
### Platforms affected

- [x] iOS
- [ ] Android
- [ ] Browser
- [ ] CI

### Motivation and Context
This change will fix an issue with the webview, where after opening and closing, the second time you open the webview, the footer is in the wrong position.

This is a small change that just restarts the footer position on the close of the InAppBrowser view.

### Testing
Tested with user sandbox app, and the fix solves the problem.
Also tested on outsystems In App Browser Sample app.

iPhone X, 11 Pro, 8 and XR.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
