### PR TITLE
RMET-753 InAppBrowser Plugin - Page scrolling to top after clicking done on input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix - 2021-06-30
+- On iOS page scrolling back to top after clicking Done in form input field [RMET-753](https://outsystemsrd.atlassian.net/browse/RMET-753)
+
 ## [4.0.0-OS5] - 2021-05-14
 ### Fix
 - Close button has an incorrect name after setting button caption as "Empty" (Android) [RMET-331](https://outsystemsrd.atlassian.net/browse/RMET-331)

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -898,7 +898,10 @@ BOOL isExiting = FALSE;
     [self.view addSubview:self.backgroundView];
     [self.view sendSubviewToBack:self.backgroundView];
 
-    if (@available(iOS 12.0, *)) {
+    if (@available(iOS 13.4, *)) {
+        // do nothing
+    }
+    else if (@available(iOS 12.0, *)) {
         [[NSNotificationCenter defaultCenter]
             addObserver:self
                selector:@selector(keyboardWillHide)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added option not to scroll back to the top of the page after closing the keyboard. This was necessary because WKWebView had a problem where the view broke after closing the keyboard. This was fixed in iOS 13.4, and as such we do not need the code in the else if branch to run for iOS versions > 13.3. This is only needed for iOS versions between 12.0 and 13.3.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
This change fixes a bug reported in a support case (RMET-753). When opening a page with a form containing input fields with InAppBrowser, after filling a field and clicking Done, the screen would jump to the top of the page, providing a bad UX. With the change made in this PR, this will no longer happen for iOS versions > 13.3.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in InAppBrowser Sample App (actually a clone because the Sample App does not contain a page with a form to open with InAppBrowser).
Also tested in the customer's app where the behaviour was first detected.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
