### PR TITLE
RMET-1231 Removed Swift Extenstions

### DIFF
--- a/src/ios/SafariBrowserPlugin.swift
+++ b/src/ios/SafariBrowserPlugin.swift
@@ -1,6 +1,6 @@
 import SafariServices
 
-class SafariBrowserPlugin: NSObject {
+class SafariBrowserPlugin: NSObject, SFSafariViewControllerDelegate {
     
     private let cacheManager: WebsiteCacheManager
     private var inAppBrowserViewController: SafariViewController?
@@ -78,10 +78,7 @@ class SafariBrowserPlugin: NSObject {
         window?.isHidden = true
         window?.resignKey()
     }
-}
 
-extension SafariBrowserPlugin: SFSafariViewControllerDelegate {
-    
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         closeBrowser()
     }


### PR DESCRIPTION
### Platforms affected
- [X] iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://outsystemsrd.atlassian.net/browse/RMET-1231

### Description
Removed the Swift class extensions do the plugin compiles with project names with non-ascii characters

### Testing
Tested with MABS on the client's app.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
