### PR TITLE
Fix memory leak

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -545,6 +545,16 @@ public class InAppBrowser extends CordovaPlugin {
                             dialog.dismiss();
                             dialog = null;
                         }
+
+                        // Fix for webView window not being destroyed correctly causing memory leak
+                        // (https://github.com/apache/cordova-plugin-inappbrowser/issues/290)
+                        if (url.equals("about:blank")) {
+                            inAppWebView.onPause();
+                            inAppWebView.removeAllViews();
+                            inAppWebView.destroyDrawingCache();
+                            inAppWebView.destroy();
+                            inAppWebView = null;
+                        }
                     }
                 });
                 // NB: From SDK 19: "If you call methods on WebView from any thread

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -358,7 +358,7 @@ public class InAppBrowser extends CordovaPlugin {
      */
     @Override
     public void onPause(boolean multitasking) {
-        if (shouldPauseInAppBrowser) {
+        if (shouldPauseInAppBrowser && inAppWebView != null) {
             inAppWebView.onPause();
         }
     }
@@ -368,7 +368,7 @@ public class InAppBrowser extends CordovaPlugin {
      */
     @Override
     public void onResume(boolean multitasking) {
-        if (shouldPauseInAppBrowser) {
+        if (shouldPauseInAppBrowser && inAppWebView != null) {
             inAppWebView.onResume();
         }
     }


### PR DESCRIPTION
Fix memory leak - initially reported in https://github.com/apache/cordova-plugin-inappbrowser/issues/290

Whenever closing an InAppBrowser instance, a webview was left in memory with about:blank page.
This change fixes the issue by destroying and freeing the inAppWebView object.



### Platforms affected

* [x] Android
* [ ] iOS

### Motivation and Context
We have detected that a web view is always left open in memory after the InAppBrowser is closed.
https://github.com/apache/cordova-plugin-inappbrowser/issues/290



### Description
We have changed the code to destroy the web view.



### Testing
The changes were tested with MABS 7.2.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
