### PR TITLE
Fix beforeLoad not being called in some requests

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -269,12 +269,6 @@ public class InAppBrowser extends CordovaPlugin {
                 @SuppressLint("NewApi")
                 @Override
                 public void run() {
-                    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
-                        currentClient.waitForBeforeload = false;
-                        inAppWebView.setWebViewClient(currentClient);
-                    } else {
-                        ((InAppBrowserClient)inAppWebView.getWebViewClient()).waitForBeforeload = false;
-                    }
                     inAppWebView.loadUrl(url);
                 }
             });
@@ -1169,7 +1163,6 @@ public class InAppBrowser extends CordovaPlugin {
         EditText edittext;
         CordovaWebView webView;
         String beforeload;
-        boolean waitForBeforeload;
 
         /**
          * Constructor.
@@ -1181,7 +1174,6 @@ public class InAppBrowser extends CordovaPlugin {
             this.webView = webView;
             this.edittext = mEditText;
             this.beforeload = beforeload;
-            this.waitForBeforeload = beforeload != null;
         }
 
         /**
@@ -1242,7 +1234,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
 
             // On first URL change, initiate JS callback. Only after the beforeload event, continue.
-            if (useBeforeload && this.waitForBeforeload) {
+            if (useBeforeload) {
                 if(sendBeforeLoad(url, method)) {
                     return true;
                 }
@@ -1337,9 +1329,6 @@ public class InAppBrowser extends CordovaPlugin {
                 }
             }
 
-            if (useBeforeload) {
-                this.waitForBeforeload = true;
-            }
             return override;
         }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -712,6 +712,8 @@ public class InAppBrowser extends CordovaPlugin {
             }
             if (features.get(BEFORELOAD) != null) {
                 beforeload = features.get(BEFORELOAD);
+            } else {
+                beforeload = "";
             }
             String fullscreenSet = features.get(FULLSCREEN);
             if (fullscreenSet != null) {

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -41,7 +41,7 @@
         _eventHandler: function (event) {
             if (event && (event.type in this.channels)) {
                 if (event.type === 'beforeload') {
-                    this.channels[event.type].fire(event, this._loadAfterBeforeload);
+                    this.channels[event.type].fire(event, this._loadAfterBeforeload.bind(this));
                 } else {
                     this.channels[event.type].fire(event);
                 }


### PR DESCRIPTION
Fix beforeLoad not being called in some requests - initially reported in https://github.com/apache/cordova-plugin-inappbrowser/issues/686


The waitForBeforeload flag was preventing beforeLoad from being called on every GET request.


### Platforms affected

* [x] Android
* [ ] iOS


### Motivation and Context
When using the beforeLoad event, we have noticed that it wasn't triggered in every navigation. The reason was related to the waitForBeforeload flag, which was intermittently set to true and bypassing the beforeLoad event.
This flag doesn't seem to be required, and there's no documentation of why it has been introduced. Some analysis of it has already been done in https://github.com/apache/cordova-plugin-inappbrowser/pull/755

Fixes https://github.com/apache/cordova-plugin-inappbrowser/issues/686




### Description
Removed the waitForBeforeload flag from the code.



### Testing
Tested with MABS 7.2.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
