### PR TITLE
Do not lose callbackContext when opening a SYSTEM url

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -164,7 +164,6 @@ public class InAppBrowser extends CordovaPlugin {
      */
     public boolean execute(String action, CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         if (action.equals("open")) {
-            this.callbackContext = callbackContext;
             final String url = args.getString(0);
             String t = args.optString(1);
             if (t == null || t.equals("") || t.equals(NULL)) {
@@ -174,6 +173,11 @@ public class InAppBrowser extends CordovaPlugin {
             final HashMap<String, String> features = parseFeature(args.optString(2));
 
             LOG.d(LOG_TAG, "target = " + target);
+
+            final boolean keepCallback = !SYSTEM.equals(target);
+            if (keepCallback) {
+                this.callbackContext = callbackContext;
+            }
 
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -252,7 +256,7 @@ public class InAppBrowser extends CordovaPlugin {
                     }
 
                     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
-                    pluginResult.setKeepCallback(true);
+                    pluginResult.setKeepCallback(keepCallback);
                     callbackContext.sendPluginResult(pluginResult);
                 }
             });


### PR DESCRIPTION
Do not lose callbackContext when opening a SYSTEM url

This fixes a condition where it was not possible to open a SYSTEM url while an InAppBrowser instance is displayed. The callbackContext of the InAppBrowser instance was lost when the SYSTEM url was opened. This fixes the issue by not setting the callbackContext on SYSTEM urls.


### Platforms affected

* [x] Android
* [ ] iOS


### Motivation and Context
Each call to inAppBrowser.open() stores a new callbackContext on the InAppBrowser object. This is required in order to trigger events and to have the javascript client respond to those events.
However, when opening a SYSTEM url (i.e. links with target="_system"), we do not need to store the callbackContext, since there are no events triggered as result of that.
Storing the callbackContext of a SYSTEM open would lose any old callbackContext, which causes problems if there is an InAppBrowser instance already active, as it would no longer listen to events.

The use case we found that requires the fix involves having a link with target="_blank" inside the content of InAppBrowser view. This link needs to be open in the system browser. We were able to convert this link into a target="_system" link, but then we lost access to the InAppBrowser instance that was open in the first place.



### Description
Do not keep or store the callbackContext when issuing an open command with SYSTEM target.



### Testing
Tested with MABS 7.2.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
