### PR TITLE
RMET-1567 Android media permissions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,13 +36,21 @@
 
     <!-- android -->
     <platform name="android">
+
         <js-module src="www/inappbrowser.js" name="inappbrowser">
             <clobbers target="cordova.InAppBrowser" />
         </js-module>
+
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="InAppBrowser">
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
+        </config-file>
+
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.CAMERA" />
+            <uses-permission android:name="android.permission.RECORD_AUDIO" />
+            <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
         </config-file>
 
         <hook type="before_plugin_install" src="hooks/outsystems/handle_cleartextTrafficPermitted.js" />

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -71,6 +71,7 @@ import org.apache.cordova.Config;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaHttpAuthHandler;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaPluginPathHandler;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginManager;
@@ -153,6 +154,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean fullscreen = true;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
+    private ShowWebpageRunnable showPageRunnable;
 
     /**
      * Executes the request and returns PluginResult.
@@ -614,7 +616,6 @@ public class InAppBrowser extends CordovaPlugin {
         this.inAppWebView.requestFocus();
     }
 
-
     /**
      * Should we show the location bar?
      *
@@ -725,378 +726,10 @@ public class InAppBrowser extends CordovaPlugin {
             }
         }
 
-        final CordovaWebView thatWebView = this.webView;
-
         // Create dialog in new thread
-        Runnable runnable = new Runnable() {
-            /**
-             * Convert our DIP units to Pixels
-             *
-             * @return int
-             */
-            private int dpToPixels(int dipValue) {
-                int value = (int) TypedValue.applyDimension( TypedValue.COMPLEX_UNIT_DIP,
-                        (float) dipValue,
-                        cordova.getActivity().getResources().getDisplayMetrics()
-                );
-
-                return value;
-            }
-
-            private View createCloseButton(int id) {
-                View _close;
-                Resources activityRes = cordova.getActivity().getResources();
-
-                if (closeButtonCaption != "") {
-                    // Use TextView for text
-                    TextView close = new TextView(cordova.getActivity());
-                    close.setText(closeButtonCaption);
-                    close.setTextSize(20);
-                    if (closeButtonColor != "") close.setTextColor(android.graphics.Color.parseColor(closeButtonColor));
-                    close.setGravity(android.view.Gravity.CENTER_VERTICAL);
-                    close.setPadding(this.dpToPixels(10), 0, this.dpToPixels(10), 0);
-                    _close = close;
-                }
-                else {
-                    ImageButton close = new ImageButton(cordova.getActivity());
-                    int closeResId = activityRes.getIdentifier("ic_action_remove", "drawable", cordova.getActivity().getPackageName());
-                    Drawable closeIcon = activityRes.getDrawable(closeResId);
-                    if (closeButtonColor != "") close.setColorFilter(android.graphics.Color.parseColor(closeButtonColor));
-                    close.setImageDrawable(closeIcon);
-                    close.setScaleType(ImageView.ScaleType.FIT_CENTER);
-                    if (Build.VERSION.SDK_INT >= 16)
-                        close.getAdjustViewBounds();
-
-                    _close = close;
-                }
-
-                RelativeLayout.LayoutParams closeLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
-                if (leftToRight) closeLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-                else closeLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                _close.setLayoutParams(closeLayoutParams);
-
-                if (Build.VERSION.SDK_INT >= 16)
-                    _close.setBackground(null);
-                else
-                    _close.setBackgroundDrawable(null);
-
-                _close.setContentDescription("Close Button");
-                _close.setId(Integer.valueOf(id));
-                _close.setOnClickListener(new View.OnClickListener() {
-                    public void onClick(View v) {
-                        closeDialog();
-                    }
-                });
-
-                return _close;
-            }
-
-            @SuppressLint("NewApi")
-            public void run() {
-
-                // CB-6702 InAppBrowser hangs when opening more than one instance
-                if (dialog != null) {
-                    dialog.dismiss();
-                };
-
-                // Let's create the main dialog
-                dialog = new InAppBrowserDialog(cordova.getActivity(), android.R.style.Theme_NoTitleBar);
-                dialog.getWindow().getAttributes().windowAnimations = android.R.style.Animation_Dialog;
-                dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-                if (fullscreen) {
-                    dialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
-                dialog.setCancelable(true);
-                dialog.setInAppBroswer(getInAppBrowser());
-
-                // Main container layout
-                LinearLayout main = new LinearLayout(cordova.getActivity());
-                main.setOrientation(LinearLayout.VERTICAL);
-
-                // Toolbar layout
-                RelativeLayout toolbar = new RelativeLayout(cordova.getActivity());
-                //Please, no more black!
-                toolbar.setBackgroundColor(toolbarColor);
-                toolbar.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44)));
-                toolbar.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
-                if (leftToRight) {
-                    toolbar.setHorizontalGravity(Gravity.LEFT);
-                } else {
-                    toolbar.setHorizontalGravity(Gravity.RIGHT);
-                }
-                toolbar.setVerticalGravity(Gravity.TOP);
-
-                // Action Button Container layout
-                RelativeLayout actionButtonContainer = new RelativeLayout(cordova.getActivity());
-                RelativeLayout.LayoutParams actionButtonLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-                if (leftToRight) actionButtonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                else actionButtonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-                actionButtonContainer.setLayoutParams(actionButtonLayoutParams);
-                actionButtonContainer.setHorizontalGravity(Gravity.LEFT);
-                actionButtonContainer.setVerticalGravity(Gravity.CENTER_VERTICAL);
-                actionButtonContainer.setId(leftToRight ? Integer.valueOf(5) : Integer.valueOf(1));
-
-                // Back button
-                ImageButton back = new ImageButton(cordova.getActivity());
-                RelativeLayout.LayoutParams backLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
-                backLayoutParams.addRule(RelativeLayout.ALIGN_LEFT);
-                back.setLayoutParams(backLayoutParams);
-                back.setContentDescription("Back Button");
-                back.setId(Integer.valueOf(2));
-                Resources activityRes = cordova.getActivity().getResources();
-                int backResId = activityRes.getIdentifier("ic_action_previous_item", "drawable", cordova.getActivity().getPackageName());
-                Drawable backIcon = activityRes.getDrawable(backResId);
-                if (navigationButtonColor != "") back.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
-                if (Build.VERSION.SDK_INT >= 16)
-                    back.setBackground(null);
-                else
-                    back.setBackgroundDrawable(null);
-                back.setImageDrawable(backIcon);
-                back.setScaleType(ImageView.ScaleType.FIT_CENTER);
-                back.setPadding(0, this.dpToPixels(10), 0, this.dpToPixels(10));
-                if (Build.VERSION.SDK_INT >= 16)
-                    back.getAdjustViewBounds();
-
-                back.setOnClickListener(new View.OnClickListener() {
-                    public void onClick(View v) {
-                        goBack();
-                    }
-                });
-
-                // Forward button
-                ImageButton forward = new ImageButton(cordova.getActivity());
-                RelativeLayout.LayoutParams forwardLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
-                forwardLayoutParams.addRule(RelativeLayout.RIGHT_OF, 2);
-                forward.setLayoutParams(forwardLayoutParams);
-                forward.setContentDescription("Forward Button");
-                forward.setId(Integer.valueOf(3));
-                int fwdResId = activityRes.getIdentifier("ic_action_next_item", "drawable", cordova.getActivity().getPackageName());
-                Drawable fwdIcon = activityRes.getDrawable(fwdResId);
-                if (navigationButtonColor != "") forward.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
-                if (Build.VERSION.SDK_INT >= 16)
-                    forward.setBackground(null);
-                else
-                    forward.setBackgroundDrawable(null);
-                forward.setImageDrawable(fwdIcon);
-                forward.setScaleType(ImageView.ScaleType.FIT_CENTER);
-                forward.setPadding(0, this.dpToPixels(10), 0, this.dpToPixels(10));
-                if (Build.VERSION.SDK_INT >= 16)
-                    forward.getAdjustViewBounds();
-
-                forward.setOnClickListener(new View.OnClickListener() {
-                    public void onClick(View v) {
-                        goForward();
-                    }
-                });
-
-                // Edit Text Box
-                edittext = new EditText(cordova.getActivity());
-                RelativeLayout.LayoutParams textLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
-                textLayoutParams.addRule(RelativeLayout.RIGHT_OF, 1);
-                textLayoutParams.addRule(RelativeLayout.LEFT_OF, 5);
-                edittext.setLayoutParams(textLayoutParams);
-                edittext.setId(Integer.valueOf(4));
-                edittext.setSingleLine(true);
-                edittext.setText(url);
-                edittext.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
-                edittext.setImeOptions(EditorInfo.IME_ACTION_GO);
-                edittext.setInputType(InputType.TYPE_NULL); // Will not except input... Makes the text NON-EDITABLE
-                edittext.setOnKeyListener(new View.OnKeyListener() {
-                    public boolean onKey(View v, int keyCode, KeyEvent event) {
-                        // If the event is a key-down event on the "enter" button
-                        if ((event.getAction() == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                            navigate(edittext.getText().toString());
-                            return true;
-                        }
-                        return false;
-                    }
-                });
-
-
-                // Header Close/Done button
-                int closeButtonId = leftToRight ? 1 : 5;
-                View close = createCloseButton(closeButtonId);
-                toolbar.addView(close);
-
-                // Footer
-                RelativeLayout footer = new RelativeLayout(cordova.getActivity());
-                int _footerColor;
-                if(footerColor != "") {
-                    _footerColor = Color.parseColor(footerColor);
-                } else {
-                    _footerColor = android.graphics.Color.LTGRAY;
-                }
-                footer.setBackgroundColor(_footerColor);
-                RelativeLayout.LayoutParams footerLayout = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44));
-                footerLayout.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
-                footer.setLayoutParams(footerLayout);
-                if (closeButtonCaption != "") footer.setPadding(this.dpToPixels(8), this.dpToPixels(8), this.dpToPixels(8), this.dpToPixels(8));
-                footer.setHorizontalGravity(Gravity.LEFT);
-                footer.setVerticalGravity(Gravity.BOTTOM);
-
-                View footerClose = createCloseButton(7);
-                footer.addView(footerClose);
-
-
-                // WebView
-                inAppWebView = new WebView(cordova.getActivity());
-                inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-                inAppWebView.setId(Integer.valueOf(6));
-                // File Chooser Implemented ChromeClient
-                inAppWebView.setWebChromeClient(new InAppChromeClient(thatWebView) {
-                    // For Android 5.0+
-                    public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
-                    {
-                        LOG.d(LOG_TAG, "File Chooser 5.0+");
-                        // If callback exists, finish it.
-                        if(mUploadCallbackLollipop != null) {
-                            mUploadCallbackLollipop.onReceiveValue(null);
-                        }
-                        mUploadCallbackLollipop = filePathCallback;
-
-                        // Create File Chooser Intent
-                        Intent content = new Intent(Intent.ACTION_GET_CONTENT);
-                        content.addCategory(Intent.CATEGORY_OPENABLE);
-                        content.setType("*/*");
-
-                        // Run cordova startActivityForResult
-                        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE_LOLLIPOP);
-                        return true;
-                    }
-
-                    // For Android 4.1+
-                    public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType, String capture)
-                    {
-                        LOG.d(LOG_TAG, "File Chooser 4.1+");
-                        // Call file chooser for Android 3.0+
-                        openFileChooser(uploadMsg, acceptType);
-                    }
-
-                    // For Android 3.0+
-                    public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType)
-                    {
-                        LOG.d(LOG_TAG, "File Chooser 3.0+");
-                        mUploadCallback = uploadMsg;
-                        Intent content = new Intent(Intent.ACTION_GET_CONTENT);
-                        content.addCategory(Intent.CATEGORY_OPENABLE);
-
-                        // run startActivityForResult
-                        cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE);
-                    }
-
-                });
-                currentClient = new InAppBrowserClient(thatWebView, edittext, beforeload);
-                inAppWebView.setWebViewClient(currentClient);
-                WebSettings settings = inAppWebView.getSettings();
-                settings.setJavaScriptEnabled(true);
-                settings.setJavaScriptCanOpenWindowsAutomatically(true);
-                settings.setBuiltInZoomControls(showZoomControls);
-                settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
-
-                // Add postMessage interface
-                class JsObject {
-                    @JavascriptInterface
-                    public void postMessage(String data) {
-                        try {
-                            JSONObject obj = new JSONObject();
-                            obj.put("type", MESSAGE_EVENT);
-                            obj.put("data", new JSONObject(data));
-                            sendUpdate(obj, true);
-                        } catch (JSONException ex) {
-                            LOG.e(LOG_TAG, "data object passed to postMessage has caused a JSON error.");
-                        }
-                    }
-                }
-
-                if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    settings.setMediaPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture);
-                    inAppWebView.addJavascriptInterface(new JsObject(), "cordova_iab");
-                }
-
-                /*
-                #RPD-2199 - Avoiding UserAgent clash in the new Native Shell
-
-                String overrideUserAgent = preferences.getString("OverrideUserAgent", null);
-                String appendUserAgent = preferences.getString("AppendUserAgent", null);
-
-                if (overrideUserAgent != null) {
-                    settings.setUserAgentString(overrideUserAgent);
-                }
-                if (appendUserAgent != null) {
-                    settings.setUserAgentString(settings.getUserAgentString() + appendUserAgent);
-                }
-                */
-
-                //Toggle whether this is enabled or not!
-                Bundle appSettings = cordova.getActivity().getIntent().getExtras();
-                boolean enableDatabase = appSettings == null ? true : appSettings.getBoolean("InAppBrowserStorageEnabled", true);
-                if (enableDatabase) {
-                    String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
-                    settings.setDatabasePath(databasePath);
-                    settings.setDatabaseEnabled(true);
-                }
-                settings.setDomStorageEnabled(true);
-
-                if (clearAllCache) {
-                    CookieManager.getInstance().removeAllCookie();
-                } else if (clearSessionCache) {
-                    CookieManager.getInstance().removeSessionCookie();
-                }
-
-                // Enable Thirdparty Cookies on >=Android 5.0 device
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-                    CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView,true);
-                }
-
-                inAppWebView.loadUrl(url);
-                inAppWebView.setId(Integer.valueOf(6));
-                inAppWebView.getSettings().setLoadWithOverviewMode(true);
-                inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);
-                inAppWebView.requestFocus();
-                inAppWebView.requestFocusFromTouch();
-
-                // Add the back and forward buttons to our action button container layout
-                actionButtonContainer.addView(back);
-                actionButtonContainer.addView(forward);
-
-                // Add the views to our toolbar if they haven't been disabled
-                if (!hideNavigationButtons) toolbar.addView(actionButtonContainer);
-                if (!hideUrlBar) toolbar.addView(edittext);
-
-                // Don't add the toolbar if its been disabled
-                if (getShowLocationBar()) {
-                    // Add our toolbar to our main view/layout
-                    main.addView(toolbar);
-                }
-
-                // Add our webview to our main view/layout
-                RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());
-                webViewLayout.addView(inAppWebView);
-                main.addView(webViewLayout);
-
-                // Don't add the footer unless it's been enabled
-                if (showFooter) {
-                    webViewLayout.addView(footer);
-                }
-
-                WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
-                lp.copyFrom(dialog.getWindow().getAttributes());
-                lp.width = WindowManager.LayoutParams.MATCH_PARENT;
-                lp.height = WindowManager.LayoutParams.MATCH_PARENT;
-
-                if (dialog != null) {
-                    dialog.setContentView(main);
-                    dialog.show();
-                    dialog.getWindow().setAttributes(lp);
-                }
-                // the goal of openhidden is to load the url and not display it
-                // Show() needs to be called to cause the URL to be loaded
-                if (openWindowHidden && dialog != null) {
-                    dialog.hide();
-                }
-            }
-        };
-        this.cordova.getActivity().runOnUiThread(runnable);
+        final CordovaWebView thatWebView = this.webView;
+        showPageRunnable = new ShowWebpageRunnable((CordovaPlugin)this, url, thatWebView);
+        this.cordova.getActivity().runOnUiThread(showPageRunnable);
         return "";
     }
 
@@ -1133,6 +766,7 @@ public class InAppBrowser extends CordovaPlugin {
      * @param resultCode the result code returned from android system
      * @param intent the data from android file chooser
      */
+    @Override
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         // For Android >= 5.0
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -1159,6 +793,13 @@ public class InAppBrowser extends CordovaPlugin {
 
             mUploadCallback.onReceiveValue(result);
             mUploadCallback = null;
+        }
+    }
+
+    @Override
+    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
+        if(requestCode == InAppChromeClient.PERMISSION_REQUEST_CODE){
+            showPageRunnable.getChromeClient().handleOnPermissionResult(permissions, grantResults);
         }
     }
 
@@ -1550,5 +1191,391 @@ public class InAppBrowser extends CordovaPlugin {
             // By default handle 401 like we'd normally do!
             super.onReceivedHttpAuthRequest(view, handler, host, realm);
         }
+    }
+
+    private class ShowWebpageRunnable implements Runnable {
+
+        private CordovaPlugin plugin;
+        private String url;
+        private CordovaWebView thatWebView;
+        private InAppChromeClient chromeClient;
+
+        public InAppChromeClient getChromeClient() {
+            return chromeClient;
+        }
+
+        public ShowWebpageRunnable(CordovaPlugin plugin, String url, CordovaWebView thatWebView) {
+            this.plugin = plugin;
+            this.url = url;
+            this.thatWebView = thatWebView;
+        }
+
+        /**
+         * Convert our DIP units to Pixels
+         *
+         * @return int
+         */
+        private int dpToPixels(int dipValue) {
+            int value = (int) TypedValue.applyDimension( TypedValue.COMPLEX_UNIT_DIP,
+                    (float) dipValue,
+                    cordova.getActivity().getResources().getDisplayMetrics()
+            );
+
+            return value;
+        }
+
+        private View createCloseButton(int id) {
+            View _close;
+            Resources activityRes = cordova.getActivity().getResources();
+
+            if (closeButtonCaption != "") {
+                // Use TextView for text
+                TextView close = new TextView(cordova.getActivity());
+                close.setText(closeButtonCaption);
+                close.setTextSize(20);
+                if (closeButtonColor != "") close.setTextColor(android.graphics.Color.parseColor(closeButtonColor));
+                close.setGravity(android.view.Gravity.CENTER_VERTICAL);
+                close.setPadding(this.dpToPixels(10), 0, this.dpToPixels(10), 0);
+                _close = close;
+            }
+            else {
+                ImageButton close = new ImageButton(cordova.getActivity());
+                int closeResId = activityRes.getIdentifier("ic_action_remove", "drawable", cordova.getActivity().getPackageName());
+                Drawable closeIcon = activityRes.getDrawable(closeResId);
+                if (closeButtonColor != "") close.setColorFilter(android.graphics.Color.parseColor(closeButtonColor));
+                close.setImageDrawable(closeIcon);
+                close.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                if (Build.VERSION.SDK_INT >= 16)
+                    close.getAdjustViewBounds();
+
+                _close = close;
+            }
+
+            RelativeLayout.LayoutParams closeLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+            if (leftToRight) closeLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+            else closeLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+            _close.setLayoutParams(closeLayoutParams);
+
+            if (Build.VERSION.SDK_INT >= 16)
+                _close.setBackground(null);
+            else
+                _close.setBackgroundDrawable(null);
+
+            _close.setContentDescription("Close Button");
+            _close.setId(Integer.valueOf(id));
+            _close.setOnClickListener(new View.OnClickListener() {
+                public void onClick(View v) {
+                    closeDialog();
+                }
+            });
+
+            return _close;
+        }
+
+        @SuppressLint("NewApi")
+        public void run() {
+
+            // CB-6702 InAppBrowser hangs when opening more than one instance
+            if (dialog != null) {
+                dialog.dismiss();
+            };
+
+            // Let's create the main dialog
+            dialog = new InAppBrowserDialog(cordova.getActivity(), android.R.style.Theme_NoTitleBar);
+            dialog.getWindow().getAttributes().windowAnimations = android.R.style.Animation_Dialog;
+            dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+            if (fullscreen) {
+                dialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            }
+            dialog.setCancelable(true);
+            dialog.setInAppBroswer(getInAppBrowser());
+
+            // Main container layout
+            LinearLayout main = new LinearLayout(cordova.getActivity());
+            main.setOrientation(LinearLayout.VERTICAL);
+
+            // Toolbar layout
+            RelativeLayout toolbar = new RelativeLayout(cordova.getActivity());
+            //Please, no more black!
+            toolbar.setBackgroundColor(toolbarColor);
+            toolbar.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44)));
+            toolbar.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
+            if (leftToRight) {
+                toolbar.setHorizontalGravity(Gravity.LEFT);
+            } else {
+                toolbar.setHorizontalGravity(Gravity.RIGHT);
+            }
+            toolbar.setVerticalGravity(Gravity.TOP);
+
+            // Action Button Container layout
+            RelativeLayout actionButtonContainer = new RelativeLayout(cordova.getActivity());
+            RelativeLayout.LayoutParams actionButtonLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+            if (leftToRight) actionButtonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+            else actionButtonLayoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+            actionButtonContainer.setLayoutParams(actionButtonLayoutParams);
+            actionButtonContainer.setHorizontalGravity(Gravity.LEFT);
+            actionButtonContainer.setVerticalGravity(Gravity.CENTER_VERTICAL);
+            actionButtonContainer.setId(leftToRight ? Integer.valueOf(5) : Integer.valueOf(1));
+
+            // Back button
+            ImageButton back = new ImageButton(cordova.getActivity());
+            RelativeLayout.LayoutParams backLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+            backLayoutParams.addRule(RelativeLayout.ALIGN_LEFT);
+            back.setLayoutParams(backLayoutParams);
+            back.setContentDescription("Back Button");
+            back.setId(Integer.valueOf(2));
+            Resources activityRes = cordova.getActivity().getResources();
+            int backResId = activityRes.getIdentifier("ic_action_previous_item", "drawable", cordova.getActivity().getPackageName());
+            Drawable backIcon = activityRes.getDrawable(backResId);
+            if (navigationButtonColor != "") back.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
+            if (Build.VERSION.SDK_INT >= 16)
+                back.setBackground(null);
+            else
+                back.setBackgroundDrawable(null);
+            back.setImageDrawable(backIcon);
+            back.setScaleType(ImageView.ScaleType.FIT_CENTER);
+            back.setPadding(0, this.dpToPixels(10), 0, this.dpToPixels(10));
+            if (Build.VERSION.SDK_INT >= 16)
+                back.getAdjustViewBounds();
+
+            back.setOnClickListener(new View.OnClickListener() {
+                public void onClick(View v) {
+                    goBack();
+                }
+            });
+
+            // Forward button
+            ImageButton forward = new ImageButton(cordova.getActivity());
+            RelativeLayout.LayoutParams forwardLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+            forwardLayoutParams.addRule(RelativeLayout.RIGHT_OF, 2);
+            forward.setLayoutParams(forwardLayoutParams);
+            forward.setContentDescription("Forward Button");
+            forward.setId(Integer.valueOf(3));
+            int fwdResId = activityRes.getIdentifier("ic_action_next_item", "drawable", cordova.getActivity().getPackageName());
+            Drawable fwdIcon = activityRes.getDrawable(fwdResId);
+            if (navigationButtonColor != "") forward.setColorFilter(android.graphics.Color.parseColor(navigationButtonColor));
+            if (Build.VERSION.SDK_INT >= 16)
+                forward.setBackground(null);
+            else
+                forward.setBackgroundDrawable(null);
+            forward.setImageDrawable(fwdIcon);
+            forward.setScaleType(ImageView.ScaleType.FIT_CENTER);
+            forward.setPadding(0, this.dpToPixels(10), 0, this.dpToPixels(10));
+            if (Build.VERSION.SDK_INT >= 16)
+                forward.getAdjustViewBounds();
+
+            forward.setOnClickListener(new View.OnClickListener() {
+                public void onClick(View v) {
+                    goForward();
+                }
+            });
+
+            // Edit Text Box
+            edittext = new EditText(cordova.getActivity());
+            RelativeLayout.LayoutParams textLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+            textLayoutParams.addRule(RelativeLayout.RIGHT_OF, 1);
+            textLayoutParams.addRule(RelativeLayout.LEFT_OF, 5);
+            edittext.setLayoutParams(textLayoutParams);
+            edittext.setId(Integer.valueOf(4));
+            edittext.setSingleLine(true);
+            edittext.setText(url);
+            edittext.setInputType(InputType.TYPE_TEXT_VARIATION_URI);
+            edittext.setImeOptions(EditorInfo.IME_ACTION_GO);
+            edittext.setInputType(InputType.TYPE_NULL); // Will not except input... Makes the text NON-EDITABLE
+            edittext.setOnKeyListener(new View.OnKeyListener() {
+                public boolean onKey(View v, int keyCode, KeyEvent event) {
+                    // If the event is a key-down event on the "enter" button
+                    if ((event.getAction() == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
+                        navigate(edittext.getText().toString());
+                        return true;
+                    }
+                    return false;
+                }
+            });
+
+            // Header Close/Done button
+            int closeButtonId = leftToRight ? 1 : 5;
+            View close = createCloseButton(closeButtonId);
+            toolbar.addView(close);
+
+            // Footer
+            RelativeLayout footer = new RelativeLayout(cordova.getActivity());
+            int _footerColor;
+            if(footerColor != "") {
+                _footerColor = Color.parseColor(footerColor);
+            } else {
+                _footerColor = android.graphics.Color.LTGRAY;
+            }
+            footer.setBackgroundColor(_footerColor);
+            RelativeLayout.LayoutParams footerLayout = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44));
+            footerLayout.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+            footer.setLayoutParams(footerLayout);
+            if (closeButtonCaption != "") footer.setPadding(this.dpToPixels(8), this.dpToPixels(8), this.dpToPixels(8), this.dpToPixels(8));
+            footer.setHorizontalGravity(Gravity.LEFT);
+            footer.setVerticalGravity(Gravity.BOTTOM);
+
+            View footerClose = createCloseButton(7);
+            footer.addView(footerClose);
+
+            // WebView
+            inAppWebView = new WebView(cordova.getActivity());
+            inAppWebView.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+            inAppWebView.setId(Integer.valueOf(6));
+            // File Chooser Implemented ChromeClient
+
+            chromeClient = new InAppChromeClient(plugin, thatWebView) {
+                // For Android 5.0+
+                public boolean onShowFileChooser (WebView webView, ValueCallback<Uri[]> filePathCallback, WebChromeClient.FileChooserParams fileChooserParams)
+                {
+                    LOG.d(LOG_TAG, "File Chooser 5.0+");
+                    // If callback exists, finish it.
+                    if(mUploadCallbackLollipop != null) {
+                        mUploadCallbackLollipop.onReceiveValue(null);
+                    }
+                    mUploadCallbackLollipop = filePathCallback;
+
+                    // Create File Chooser Intent
+                    Intent content = new Intent(Intent.ACTION_GET_CONTENT);
+                    content.addCategory(Intent.CATEGORY_OPENABLE);
+                    content.setType("*/*");
+
+                    // Run cordova startActivityForResult
+                    cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE_LOLLIPOP);
+                    return true;
+                }
+
+                // For Android 4.1+
+                public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType, String capture)
+                {
+                    LOG.d(LOG_TAG, "File Chooser 4.1+");
+                    // Call file chooser for Android 3.0+
+                    openFileChooser(uploadMsg, acceptType);
+                }
+
+                // For Android 3.0+
+                public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType)
+                {
+                    LOG.d(LOG_TAG, "File Chooser 3.0+");
+                    mUploadCallback = uploadMsg;
+                    Intent content = new Intent(Intent.ACTION_GET_CONTENT);
+                    content.addCategory(Intent.CATEGORY_OPENABLE);
+
+                    // run startActivityForResult
+                    cordova.startActivityForResult(InAppBrowser.this, Intent.createChooser(content, "Select File"), FILECHOOSER_REQUESTCODE);
+                }
+
+            };
+            inAppWebView.setWebChromeClient(chromeClient);
+            currentClient = new InAppBrowserClient(thatWebView, edittext, beforeload);
+            inAppWebView.setWebViewClient(currentClient);
+            WebSettings settings = inAppWebView.getSettings();
+            settings.setJavaScriptEnabled(true);
+            settings.setJavaScriptCanOpenWindowsAutomatically(true);
+            settings.setBuiltInZoomControls(showZoomControls);
+            settings.setPluginState(android.webkit.WebSettings.PluginState.ON);
+
+            // Add postMessage interface
+            class JsObject {
+                @JavascriptInterface
+                public void postMessage(String data) {
+                    try {
+                        JSONObject obj = new JSONObject();
+                        obj.put("type", MESSAGE_EVENT);
+                        obj.put("data", new JSONObject(data));
+                        sendUpdate(obj, true);
+                    } catch (JSONException ex) {
+                        LOG.e(LOG_TAG, "data object passed to postMessage has caused a JSON error.");
+                    }
+                }
+            }
+
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                settings.setMediaPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture);
+                inAppWebView.addJavascriptInterface(new JsObject(), "cordova_iab");
+            }
+
+                /*
+                #RPD-2199 - Avoiding UserAgent clash in the new Native Shell
+
+                String overrideUserAgent = preferences.getString("OverrideUserAgent", null);
+                String appendUserAgent = preferences.getString("AppendUserAgent", null);
+
+                if (overrideUserAgent != null) {
+                    settings.setUserAgentString(overrideUserAgent);
+                }
+                if (appendUserAgent != null) {
+                    settings.setUserAgentString(settings.getUserAgentString() + appendUserAgent);
+                }
+                */
+
+            //Toggle whether this is enabled or not!
+            Bundle appSettings = cordova.getActivity().getIntent().getExtras();
+            boolean enableDatabase = appSettings == null ? true : appSettings.getBoolean("InAppBrowserStorageEnabled", true);
+            if (enableDatabase) {
+                String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
+                settings.setDatabasePath(databasePath);
+                settings.setDatabaseEnabled(true);
+            }
+            settings.setDomStorageEnabled(true);
+
+            if (clearAllCache) {
+                CookieManager.getInstance().removeAllCookie();
+            } else if (clearSessionCache) {
+                CookieManager.getInstance().removeSessionCookie();
+            }
+
+            // Enable Thirdparty Cookies on >=Android 5.0 device
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                CookieManager.getInstance().setAcceptThirdPartyCookies(inAppWebView,true);
+            }
+
+            inAppWebView.loadUrl(url);
+            inAppWebView.setId(Integer.valueOf(6));
+            inAppWebView.getSettings().setLoadWithOverviewMode(true);
+            inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);
+            inAppWebView.requestFocus();
+            inAppWebView.requestFocusFromTouch();
+
+            // Add the back and forward buttons to our action button container layout
+            actionButtonContainer.addView(back);
+            actionButtonContainer.addView(forward);
+
+            // Add the views to our toolbar if they haven't been disabled
+            if (!hideNavigationButtons) toolbar.addView(actionButtonContainer);
+            if (!hideUrlBar) toolbar.addView(edittext);
+
+            // Don't add the toolbar if its been disabled
+            if (getShowLocationBar()) {
+                // Add our toolbar to our main view/layout
+                main.addView(toolbar);
+            }
+
+            // Add our webview to our main view/layout
+            RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());
+            webViewLayout.addView(inAppWebView);
+            main.addView(webViewLayout);
+
+            // Don't add the footer unless it's been enabled
+            if (showFooter) {
+                webViewLayout.addView(footer);
+            }
+
+            WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+            lp.copyFrom(dialog.getWindow().getAttributes());
+            lp.width = WindowManager.LayoutParams.MATCH_PARENT;
+            lp.height = WindowManager.LayoutParams.MATCH_PARENT;
+
+            if (dialog != null) {
+                dialog.setContentView(main);
+                dialog.show();
+                dialog.getWindow().setAttributes(lp);
+            }
+            // the goal of openhidden is to load the url and not display it
+            // Show() needs to be called to cause the URL to be loaded
+            if (openWindowHidden && dialog != null) {
+                dialog.hide();
+            }
+        }
+
     }
 }

--- a/src/android/InAppChromeClient.java
+++ b/src/android/InAppChromeClient.java
@@ -21,25 +21,37 @@ package org.apache.cordova.inappbrowser;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PermissionHelper;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import android.Manifest;
+import android.util.Log;
 import android.webkit.JsPromptResult;
+import android.webkit.PermissionRequest;
 import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.GeolocationPermissions.Callback;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class InAppChromeClient extends WebChromeClient {
 
     private CordovaWebView webView;
-    private String LOG_TAG = "InAppChromeClient";
+    private CordovaPlugin plugin;
+    private static String LOG_TAG = "InAppChromeClient";
+    public static int PERMISSION_REQUEST_CODE = 11223344;
     private long MAX_QUOTA = 100 * 1024 * 1024;
+    private PermissionRequest lastPermissionRequest;
 
-    public InAppChromeClient(CordovaWebView webView) {
+    public InAppChromeClient(CordovaPlugin plugin, CordovaWebView webView) {
         super();
         this.webView = webView;
+        this.plugin = plugin;
     }
     /**
      * Handle database quota exceeded notification.
@@ -52,9 +64,12 @@ public class InAppChromeClient extends WebChromeClient {
      * @param quotaUpdater
      */
     @Override
-    public void onExceededDatabaseQuota(String url, String databaseIdentifier, long currentQuota, long estimatedSize,
-            long totalUsedQuota, WebStorage.QuotaUpdater quotaUpdater)
-    {
+    public void onExceededDatabaseQuota(String url,
+                                        String databaseIdentifier,
+                                        long currentQuota,
+                                        long estimatedSize,
+                                        long totalUsedQuota,
+                                        WebStorage.QuotaUpdater quotaUpdater) {
         LOG.d(LOG_TAG, "onExceededDatabaseQuota estimatedSize: %d  currentQuota: %d  totalUsedQuota: %d", estimatedSize, currentQuota, totalUsedQuota);
         quotaUpdater.updateQuota(MAX_QUOTA);
     }
@@ -134,5 +149,57 @@ public class InAppChromeClient extends WebChromeClient {
         }
         return false;
     }
+
+    @Override
+    public void onPermissionRequest(PermissionRequest request) {
+
+        List<String> permissions = new ArrayList<String>();
+        for (String r: request.getResources()) {
+            switch (r){
+                case "android.webkit.resource.AUDIO_CAPTURE": {
+                    if(!PermissionHelper.hasPermission(plugin, Manifest.permission.MODIFY_AUDIO_SETTINGS)){
+                        permissions.add(Manifest.permission.MODIFY_AUDIO_SETTINGS);
+                    }
+                    if(!PermissionHelper.hasPermission(plugin, Manifest.permission.RECORD_AUDIO)){
+                        permissions.add(Manifest.permission.RECORD_AUDIO);
+                    }
+                    break;
+                }
+                case "android.webkit.resource.VIDEO_CAPTURE": {
+                    if(!PermissionHelper.hasPermission(plugin, Manifest.permission.CAMERA)){
+                        permissions.add(Manifest.permission.CAMERA);
+                    }
+                    break;
+                }
+                default: {
+                    Log.d(LOG_TAG, "Permission not found for: " + r);
+                    break;
+                }
+            }
+        }
+
+        if(permissions.size() > 0) {
+            String[] permissionArray = new String[permissions.size()];
+            permissionArray = permissions.toArray(permissionArray);
+            lastPermissionRequest = request;
+            plugin.cordova.setActivityResultCallback(plugin);
+            PermissionHelper.requestPermissions(plugin, PERMISSION_REQUEST_CODE, permissionArray);
+            Log.d(LOG_TAG, "Requesting permissions :" + permissions);
+        }
+        else {
+            request.grant(request.getResources());
+        }
+    }
+
+    @Override
+    public void onPermissionRequestCanceled(PermissionRequest request) {
+        super.onPermissionRequestCanceled(request);
+        Log.d(LOG_TAG, "Permission request canceled");
+    }
+
+    public void handleOnPermissionResult(String[] permissions, int[] grantResults) {
+        lastPermissionRequest.grant(lastPermissionRequest.getResources());
+    }
+
 
 }

--- a/src/android/InAppChromeClient.java
+++ b/src/android/InAppChromeClient.java
@@ -182,7 +182,6 @@ public class InAppChromeClient extends WebChromeClient {
             String[] permissionArray = new String[permissions.size()];
             permissionArray = permissions.toArray(permissionArray);
             lastPermissionRequest = request;
-            plugin.cordova.setActivityResultCallback(plugin);
             PermissionHelper.requestPermissions(plugin, PERMISSION_REQUEST_CODE, permissionArray);
             Log.d(LOG_TAG, "Requesting permissions :" + permissions);
         }
@@ -200,6 +199,5 @@ public class InAppChromeClient extends WebChromeClient {
     public void handleOnPermissionResult(String[] permissions, int[] grantResults) {
         lastPermissionRequest.grant(lastPermissionRequest.getResources());
     }
-
 
 }


### PR DESCRIPTION
### Motivation and Context
https://outsystemsrd.atlassian.net/browse/RMET-1567
InAppBrowser did not ask for camera / microphone permissions when opened as "InAppBrowser". This is necessary for android to correctly show web video and audio calls using InAppBrowser.

### Description
InAppBrowser uses a custom made ChromeWebClient. This class is responsible for responding to permission requests.
We created login on method "onPermissionRequest" that identifies camera and microphone perm requests and then forwards them to cordova's permission helper.

### Testing
These changes were tested with MABS. Customer confirmed that this fixes their issue.

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary

### Platforms affected
- [ ] iOS
- [X] Android
