### PR TITLE
RMET-2802 InAppBrowser Plugin - Multiple minor fixes from the community

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -269,12 +269,6 @@ public class InAppBrowser extends CordovaPlugin {
                 @SuppressLint("NewApi")
                 @Override
                 public void run() {
-                    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
-                        currentClient.waitForBeforeload = false;
-                        inAppWebView.setWebViewClient(currentClient);
-                    } else {
-                        ((InAppBrowserClient)inAppWebView.getWebViewClient()).waitForBeforeload = false;
-                    }
                     inAppWebView.loadUrl(url);
                 }
             });
@@ -1169,7 +1163,6 @@ public class InAppBrowser extends CordovaPlugin {
         EditText edittext;
         CordovaWebView webView;
         String beforeload;
-        boolean waitForBeforeload;
 
         /**
          * Constructor.
@@ -1181,7 +1174,6 @@ public class InAppBrowser extends CordovaPlugin {
             this.webView = webView;
             this.edittext = mEditText;
             this.beforeload = beforeload;
-            this.waitForBeforeload = beforeload != null;
         }
 
         /**
@@ -1242,7 +1234,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
 
             // On first URL change, initiate JS callback. Only after the beforeload event, continue.
-            if (useBeforeload && this.waitForBeforeload) {
+            if (useBeforeload) {
                 if(sendBeforeLoad(url, method)) {
                     return true;
                 }
@@ -1337,9 +1329,6 @@ public class InAppBrowser extends CordovaPlugin {
                 }
             }
 
-            if (useBeforeload) {
-                this.waitForBeforeload = true;
-            }
             return override;
         }
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -545,6 +545,16 @@ public class InAppBrowser extends CordovaPlugin {
                             dialog.dismiss();
                             dialog = null;
                         }
+
+                        // Fix for webView window not being destroyed correctly causing memory leak
+                        // (https://github.com/apache/cordova-plugin-inappbrowser/issues/290)
+                        if (url.equals("about:blank")) {
+                            inAppWebView.onPause();
+                            inAppWebView.removeAllViews();
+                            inAppWebView.destroyDrawingCache();
+                            inAppWebView.destroy();
+                            inAppWebView = null;
+                        }
                     }
                 });
                 // NB: From SDK 19: "If you call methods on WebView from any thread

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -358,7 +358,7 @@ public class InAppBrowser extends CordovaPlugin {
      */
     @Override
     public void onPause(boolean multitasking) {
-        if (shouldPauseInAppBrowser) {
+        if (shouldPauseInAppBrowser && inAppWebView != null) {
             inAppWebView.onPause();
         }
     }
@@ -368,7 +368,7 @@ public class InAppBrowser extends CordovaPlugin {
      */
     @Override
     public void onResume(boolean multitasking) {
-        if (shouldPauseInAppBrowser) {
+        if (shouldPauseInAppBrowser && inAppWebView != null) {
             inAppWebView.onResume();
         }
     }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -164,7 +164,6 @@ public class InAppBrowser extends CordovaPlugin {
      */
     public boolean execute(String action, CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
         if (action.equals("open")) {
-            this.callbackContext = callbackContext;
             final String url = args.getString(0);
             String t = args.optString(1);
             if (t == null || t.equals("") || t.equals(NULL)) {
@@ -174,6 +173,11 @@ public class InAppBrowser extends CordovaPlugin {
             final HashMap<String, String> features = parseFeature(args.optString(2));
 
             LOG.d(LOG_TAG, "target = " + target);
+
+            final boolean keepCallback = !SYSTEM.equals(target);
+            if (keepCallback) {
+                this.callbackContext = callbackContext;
+            }
 
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -252,7 +256,7 @@ public class InAppBrowser extends CordovaPlugin {
                     }
 
                     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
-                    pluginResult.setKeepCallback(true);
+                    pluginResult.setKeepCallback(keepCallback);
                     callbackContext.sendPluginResult(pluginResult);
                 }
             });

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -712,6 +712,8 @@ public class InAppBrowser extends CordovaPlugin {
             }
             if (features.get(BEFORELOAD) != null) {
                 beforeload = features.get(BEFORELOAD);
+            } else {
+                beforeload = "";
             }
             String fullscreenSet = features.get(FULLSCREEN);
             if (fullscreenSet != null) {

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -41,7 +41,7 @@
         _eventHandler: function (event) {
             if (event && (event.type in this.channels)) {
                 if (event.type === 'beforeload') {
-                    this.channels[event.type].fire(event, this._loadAfterBeforeload);
+                    this.channels[event.type].fire(event, this._loadAfterBeforeload.bind(this));
                 } else {
                     this.channels[event.type].fire(event);
                 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR contains 3 fixes that came from the community, from the following PRs: https://github.com/OutSystems/cordova-plugin-inappbrowser/pulls?q=is%3Apr+author%3Aleonardo-fernandes.
- The fixes include:
    - Not loosing the `callbackContext` when opening a `SYSTEM_URL`
    - Fixing beforeLoad not being called in every request.
    - Fixing a memory leak - webview was being left in memory unnecessarily. 
- A more thorough explanation for each fix is available on each PR.
- The PR also includes some refactors regarding ternary operators.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2802

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [x] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested on both Android (12 and 14) and iOS (17), with the InAppBrowser Sample App (tested every feature in the app).

- MABS 9 Android build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=bd50be7f72b1bfac4de1a0241117b081eb641694
- MABS 9 iOS build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=713c7bb486a8f916997d349a095f98b02c965d3d

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
